### PR TITLE
Add State Bucket to Project Deployment

### DIFF
--- a/gcp/project/README.md
+++ b/gcp/project/README.md
@@ -55,6 +55,7 @@ No requirements.
 | Name | Type |
 |------|------|
 | [google_project.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
+| [google_storage_bucket.state](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/storage_bucket) | data source |
 
 ## Inputs
 
@@ -64,6 +65,7 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_audit_log_config"></a> [audit\_log\_config](#output\_audit\_log\_config) | Audit configuration on the configured project |
 | <a name="output_billing_account"></a> [billing\_account](#output\_billing\_account) | Billing account of the configured project |
 | <a name="output_enabled_apis"></a> [enabled\_apis](#output\_enabled\_apis) | APIs enabled on the configured project |
 | <a name="output_folder_id"></a> [folder\_id](#output\_folder\_id) | ID of the configured project's parent folder |
@@ -71,4 +73,8 @@ No inputs.
 | <a name="output_project_id"></a> [project\_id](#output\_project\_id) | ID of the configured project |
 | <a name="output_project_labels"></a> [project\_labels](#output\_project\_labels) | Labels configured on the project |
 | <a name="output_project_name"></a> [project\_name](#output\_project\_name) | Name of the configured project |
+| <a name="output_state_bucket_labels"></a> [state\_bucket\_labels](#output\_state\_bucket\_labels) | Labels configured on the state bucket for the configured project |
+| <a name="output_state_bucket_name"></a> [state\_bucket\_name](#output\_state\_bucket\_name) | Name of the Terraform state bucket for the configured project |
+| <a name="output_state_bucket_project"></a> [state\_bucket\_project](#output\_state\_bucket\_project) | Parent project of the Terraform state bucket for the configured project |
+| <a name="output_state_bucket_versioning"></a> [state\_bucket\_versioning](#output\_state\_bucket\_versioning) | Versioning configuration on the state bucket for the configured project |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/gcp/project/inputs.yaml
+++ b/gcp/project/inputs.yaml
@@ -40,3 +40,7 @@ project:
   folder_id_override: ""
   project_id_override: ""
   random_project_id: true
+  state_bucket:
+    force_destroy: false
+    uniform_access: true
+    versioning: true


### PR DESCRIPTION
- adds state bucket to the project factory composition, including inputs, configuration, and outputs
- adds state bucket tests to the test module
- adds audit log configuration tests to the test module

Note: Uses build project for state storage bucket, so that state is external to the deployment
